### PR TITLE
Add builds for OSX and Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,8 @@ jobs:
 
     - name: 'Compile provider'
       run: |
-        go build -o terraform.d/plugins/linux_amd64/terraform-provider-kustomization
+        GOOS=linux GOARCH=amd64 go build -o terraform.d/plugins/linux_amd64/terraform-provider-kustomization
+        GOOS=darwin GOARCH=amd64 go build -o terraform.d/plugins/darwin_amd64/terraform-provider-kustomization
         ls -al
         pwd
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
       run: |
         GOOS=linux GOARCH=amd64 go build -o terraform.d/plugins/linux_amd64/terraform-provider-kustomization
         GOOS=darwin GOARCH=amd64 go build -o terraform.d/plugins/darwin_amd64/terraform-provider-kustomization
+        GOOS=windows GOARCH=amd64 go build -o terraform.d/plugins/windows_amd64/terraform-provider-kustomization
         ls -al
         pwd
 


### PR DESCRIPTION
Hey there!

This PR adds a step into the build process to create a binary for the darwin/amd64 and windows/amd64 architectures.
