### PR TITLE
Improve resiliency of kustomization_resource create and delete

### DIFF
--- a/test_kustomizations/crd/co.yaml
+++ b/test_kustomizations/crd/co.yaml
@@ -1,0 +1,12 @@
+apiVersion: test.example.com/v1alpha1
+kind: Namespacedcrd
+metadata:
+  name: namespacedco
+  namespace: test-crd
+spec: {}
+---
+apiVersion: test.example.com/v1alpha1
+kind: Clusteredcrd
+metadata:
+  name: clusteredco
+spec: {}

--- a/test_kustomizations/crd/crd.yaml
+++ b/test_kustomizations/crd/crd.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: namespacedcrds.test.example.com
+spec:
+  group: test.example.com
+  names:
+    kind: Namespacedcrd
+    plural: namespacedcrds
+    shortNames:
+    - ncrds
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusteredcrds.test.example.com
+spec:
+  group: test.example.com
+  names:
+    kind: Clusteredcrd
+    plural: clusteredcrds
+    shortNames:
+    - ccrds
+  scope: Cluster
+  version: v1alpha1

--- a/test_kustomizations/crd/kustomization.yaml
+++ b/test_kustomizations/crd/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- namespace.yaml
+- crd.yaml
+- co.yaml

--- a/test_kustomizations/crd/namespace.yaml
+++ b/test_kustomizations/crd/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-crd


### PR DESCRIPTION
 * Create: Wait for namespaces to exist and retry creation
   A namespace and resources in that namespace created during
   the same terraform apply should not cause an error, when
   terraform tries to create the resource before the K8s api
   is done creating the namespace.

 * Create: Wait for CRDs to exist and retry creation
   A CRD and an resource of kind THIS_CRD created during the
   same terraform apply should not cause the apply to fail.

 * Delete: Consider not found error a success on deletion
   A resource, that was deleted as part of a namespace being
   deleted should not cause an error when it returns not found
   during a terraform destroy.