### PR TITLE
Use strategic-merge-patch instead of merge-patch

### DIFF
--- a/kustomize/resource_kustomization.go
+++ b/kustomize/resource_kustomization.go
@@ -207,7 +207,7 @@ func kustomizationResourceDiff(d *schema.ResourceDiff, m interface{}) error {
 	_, err = client.
 		Resource(gvr).
 		Namespace(namespace).
-		Patch(context.TODO(), name, k8stypes.MergePatchType, patch, dryRunPatch)
+		Patch(context.TODO(), name, k8stypes.StrategicMergePatchType, patch, dryRunPatch)
 	if err != nil {
 		//
 		//
@@ -306,7 +306,7 @@ func kustomizationResourceUpdate(d *schema.ResourceData, m interface{}) error {
 	patchResp, err := client.
 		Resource(gvr).
 		Namespace(namespace).
-		Patch(context.TODO(), name, k8stypes.MergePatchType, patch, k8smetav1.PatchOptions{})
+		Patch(context.TODO(), name, k8stypes.StrategicMergePatchType, patch, k8smetav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("ResourceUpdate: patching '%s' failed: %s", gvr, err)
 	}


### PR DESCRIPTION
We noticed an issue that our service resource without `NodePort` specified in kustomization can cause the existing `NodePort` value to be erased in cluster after applying. That caused the service few minutes of downtime until a new nodePort was allocated and such behavior was never inspected when we applied/patched the kustomization using `kubectl` before.

After investigation, we found the issue was due to the terraform provider was using `merge` rather than `strategic merge` when patching the kubernetes resources. To be short, `merge` would actually replace the whole existing values even if some are unset in patch, while `strategic` is bit "smarter" in keeping the unspecified fields values in cluster.

Here we can find more info about `strategic` vs `merge`: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment.

I believe changing to `strategic` in the provider would be the right direction to go. Also note the fact that `kubectl apply/edit` only use `strategic` and `kubectl patch` uses it by default too. 

