### PR TITLE
Work against current kubernetes resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.8.0 // indirect
 	github.com/aws/aws-sdk-go v1.25.31 // indirect
 	github.com/emicklei/go-restful v2.11.1+incompatible // indirect
+	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gophercloud/gophercloud v0.6.0 // indirect

--- a/kustomize/resource_kustomization.go
+++ b/kustomize/resource_kustomization.go
@@ -74,8 +74,6 @@ func kustomizationResourceCreate(d *schema.ResourceData, m interface{}) error {
 	gvr := gvrResp.(k8sschema.GroupVersionResource)
 	namespace := u.GetNamespace()
 
-	setLastAppliedConfig(u, srcJSON)
-
 	if namespace != "" {
 		// wait for the namespace to exist
 		nsGvk := k8sschema.GroupVersionKind{
@@ -125,7 +123,7 @@ func kustomizationResourceCreate(d *schema.ResourceData, m interface{}) error {
 	id := string(resp.GetUID())
 	d.SetId(id)
 
-	d.Set("manifest", getLastAppliedConfig(resp))
+	d.Set("manifest", getSimplified(resp, []byte(srcJSON)))
 
 	return kustomizationResourceRead(d, m)
 }
@@ -134,7 +132,9 @@ func kustomizationResourceRead(d *schema.ResourceData, m interface{}) error {
 	client := m.(*Config).Client
 	clientset := m.(*Config).Clientset
 
-	u, err := parseJSON(d.Get("manifest").(string))
+	srcJSON := d.Get("manifest").(string)
+	u, err := parseJSON(srcJSON)
+
 	if err != nil {
 		return fmt.Errorf("ResourceRead: %s", err)
 	}
@@ -157,7 +157,7 @@ func kustomizationResourceRead(d *schema.ResourceData, m interface{}) error {
 	id := string(resp.GetUID())
 	d.SetId(id)
 
-	d.Set("manifest", getLastAppliedConfig(resp))
+	d.Set("manifest", getSimplified(resp, []byte(srcJSON)))
 
 	return nil
 }
@@ -314,7 +314,7 @@ func kustomizationResourceUpdate(d *schema.ResourceData, m interface{}) error {
 	id := string(patchResp.GetUID())
 	d.SetId(id)
 
-	d.Set("manifest", getLastAppliedConfig(patchResp))
+	d.Set("manifest", getSimplified(patchResp, modified))
 
 	return kustomizationResourceRead(d, m)
 }
@@ -408,7 +408,8 @@ func kustomizationResourceImport(d *schema.ResourceData, m interface{}) ([]*sche
 	id := string(resp.GetUID())
 	d.SetId(id)
 
-	d.Set("manifest", getLastAppliedConfig(resp))
+	srcJSON := d.Get("manifest").(string)
+	d.Set("manifest", getSimplified(resp, []byte(srcJSON)))
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/kustomize/structures_kustomization.go
+++ b/kustomize/structures_kustomization.go
@@ -2,6 +2,7 @@ package kustomize
 
 import (
 	"sigs.k8s.io/kustomize/api/resmap"
+	"strings"
 )
 
 func flattenKustomizationIDs(rm resmap.ResMap) (ids []string) {
@@ -20,7 +21,7 @@ func flattenKustomizationResources(rm resmap.ResMap) (res map[string]string, err
 		if err != nil {
 			return nil, err
 		}
-		res[id] = string(json)
+		res[id] = strings.Trim(string(json), "\n")
 	}
 
 	return res, nil

--- a/kustomize/util.go
+++ b/kustomize/util.go
@@ -3,8 +3,7 @@ package kustomize
 import (
 	"context"
 	"fmt"
-
-	k8scorev1 "k8s.io/api/core/v1"
+	jsonpatch "github.com/evanphx/json-patch"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -17,19 +16,36 @@ import (
 	"k8s.io/apimachinery/pkg/util/mergepatch"
 )
 
-const lastAppliedConfig = k8scorev1.LastAppliedConfigAnnotation
-
-func setLastAppliedConfig(u *k8sunstructured.Unstructured, srcJSON string) {
-	annotations := u.GetAnnotations()
-	if len(annotations) == 0 {
-		annotations = make(map[string]string)
-	}
-	annotations[lastAppliedConfig] = srcJSON
-	u.SetAnnotations(annotations)
+// Get a simplified json from resp by stripping excessive fields based on targeted.
+// Mainly for eliminating unwanted noisy diff in terraform plan.
+func getSimplified(resp *k8sunstructured.Unstructured, targeted []byte) string {
+	bytes, _ := resp.MarshalJSON()
+	simplified, _ := simplifyJSON(bytes, targeted)
+	return string(simplified)
 }
 
-func getLastAppliedConfig(u *k8sunstructured.Unstructured) string {
-	return u.GetAnnotations()[lastAppliedConfig]
+func simplifyJSON(full, targeted []byte) (simplified []byte, err error) {
+	if cap(targeted) == 0 {
+		return full, nil
+	}
+	var preconditions []mergepatch.PreconditionFunc
+
+	patch1, err := jsonmergepatch.CreateThreeWayJSONMergePatch(targeted, full, full, preconditions...)
+	if err != nil {
+		return nil, err
+	}
+
+	patched, err := jsonpatch.MergePatch(full, patch1)
+	if err != nil {
+		return nil, err
+	}
+
+	patch2, err := jsonmergepatch.CreateThreeWayJSONMergePatch(full, targeted, targeted, preconditions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonpatch.MergePatch(patched, patch2)
 }
 
 func getOriginalModifiedCurrent(originalJSON string, modifiedJSON string, currentAllowNotFound bool, m interface{}) (original []byte, modified []byte, current []byte, err error) {
@@ -44,9 +60,6 @@ func getOriginalModifiedCurrent(originalJSON string, modifiedJSON string, curren
 	if err != nil {
 		return nil, nil, nil, err
 	}
-
-	setLastAppliedConfig(o, originalJSON)
-	setLastAppliedConfig(n, modifiedJSON)
 
 	gvr, err := getGVR(o.GroupVersionKind(), clientset)
 	if err != nil {

--- a/kustomize/util_test.go
+++ b/kustomize/util_test.go
@@ -1,28 +1,10 @@
 package kustomize
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 )
-
-func TestLastAppliedConfig(t *testing.T) {
-	srcJSON := "{\"apiVersion\": \"v1\", \"kind\": \"Namespace\", \"metadata\": {\"name\": \"test-unit\"}}"
-	u, err := parseJSON(srcJSON)
-	if err != nil {
-		t.Errorf("Error: %s", err)
-	}
-	setLastAppliedConfig(u, srcJSON)
-
-	annotations := u.GetAnnotations()
-	count := len(annotations)
-	if count != 1 {
-		t.Errorf("TestLastAppliedConfig: incorect number of annotations, got: %d, want: %d.", count, 1)
-	}
-
-	lac := getLastAppliedConfig(u)
-	if lac != srcJSON {
-		t.Errorf("TestLastAppliedConfig: incorect annotation value, got: %s, want: %s.", srcJSON, lac)
-	}
-}
 
 func TestGetPatch(t *testing.T) {
 	srcJSON := "{\"apiVersion\": \"v1\", \"kind\": \"Namespace\", \"metadata\": {\"name\": \"test-unit\"}}"
@@ -38,5 +20,111 @@ func TestGetPatch(t *testing.T) {
 	_, err := getPatch(original, modified, current)
 	if err != nil {
 		t.Errorf("TestGetPatch: %s", err)
+	}
+}
+
+func TestSimplifyJSON(t *testing.T) {
+	full := `{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "creationTimestamp": "2020-02-24T06:37:48Z",
+    "labels": {
+      "app": "foo"
+    },
+    "name": "foo",
+    "namespace": "test",
+    "resourceVersion": "70032962",
+    "selfLink": "/api/v1/namespaces/test/services/foo",
+    "uid": "2c0baf14-56d0-11ea-a787-42010a0e000b"
+  },
+  "spec": {
+    "clusterIP": "10.12.38.10",
+    "externalTrafficPolicy": "Cluster",
+    "ports": [
+      {
+        "name": "http",
+        "nodePort": 31033,
+        "port": 8080,
+        "protocol": "TCP",
+        "targetPort": "http"
+      }
+    ],
+    "selector": {
+      "app": "foo"
+    },
+    "sessionAffinity": "None",
+    "type": "NodePort"
+  },
+  "status": {
+    "loadBalancer": {}
+  }
+}`
+
+	targeted := `{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "foo"
+  },
+  "spec": {
+    "externalTrafficPolicy": "Cluster",
+    "ports": [
+      {
+        "name": "http",
+        "port": 7070,
+        "protocol": "TCP",
+        "targetPort": "http"
+      },
+      {
+        "name": "monitoring",
+        "port": 6666,
+        "protocol": "TCP",
+        "targetPort": "monitoring"
+      }
+    ],
+    "selector": {
+      "app": "bar"
+    },
+    "sessionAffinity": "None",
+    "type": "NodePort"
+  }
+}`
+
+	expected := `{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "foo"
+  },
+  "spec": {
+    "externalTrafficPolicy": "Cluster",
+    "ports": [
+      {
+        "name": "http",
+        "nodePort": 31033,
+        "port": 8080,
+        "protocol": "TCP",
+        "targetPort": "http"
+      }
+    ],
+    "selector": {
+      "app": "foo"
+    },
+    "sessionAffinity": "None",
+    "type": "NodePort"
+  }
+}`
+
+	result, err := simplifyJSON([]byte(full), []byte(targeted))
+	if err != nil {
+		t.Errorf("TestSimplify: %s", err)
+	}
+
+	var resultPretty bytes.Buffer
+	_ = json.Indent(&resultPretty, result, "", "  ")
+
+	if expected != string(resultPretty.Bytes()) {
+		t.Errorf("expected: %s\n got: %s", expected, resultPretty.Bytes())
 	}
 }


### PR DESCRIPTION
This PR is to change to work against the actual kubernetes resources rather than the values stored in `last-applied-configuration`. 
When someone changed stuff in the cluster without this terraform provider (e.g., `kubectl`) the resource's `last-applied-configuration` is altered and content of it is outdated. Later when people do a terraform refresh or plan, that stale data is refreshed into the state, causing expected diff and behaviours. 

This fix attempts to rectify the issue by working against the actual kubernetes cluster resources (and store them in state too), like most of the other terraform providers do. 
One challenge we are facing is the noisy terraform diff when things come to compare between your stuff to apply vs what is in the cluster, such as the excessive `creationTimestamp`, `resourceVersion` and `uid` fields which only exist in the cluster, as well as some optional fields that can be omitted in kustomize. Here I am resolving it by stripping fields from the verbose resource based on what we provide as the kustomization data (see the `getSimplified` in util.go). This solution is not perfect and it assumes the existence of the kustomize resource to be well defined with all necessary fields in the first place. Though the dry-run in the provider's `Diff` impl can more or less guarantee the integrity of the kustomize stuff to be applied, there is still a risk that some optional fields not represented in kustomize code can incorrectly hide them when showing the terraform plan.

For now this fix is mostly working with our use cases with kustommize but we're still seeking for a more elegant solution. Any advice welcomed. 