### PR TITLE
Cache `restmapper.GetAPIGroupResources` response in provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,15 +8,14 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.8.0 // indirect
 	github.com/aws/aws-sdk-go v1.25.31 // indirect
 	github.com/emicklei/go-restful v2.11.1+incompatible // indirect
-	github.com/go-openapi/jsonreference v0.19.3 // indirect
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gophercloud/gophercloud v0.6.0 // indirect
 	github.com/hashicorp/go-hclog v0.10.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.4.0
 	github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
-	github.com/mailru/easyjson v0.7.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/posener/complete v1.2.2 // indirect
 	github.com/ulikunitz/xz v0.5.6 // indirect
 	golang.org/x/tools v0.0.0-20200513154647-78b527d18275 // indirect

--- a/go.sum
+++ b/go.sum
@@ -465,6 +465,9 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/patrickmn/go-cache v1.0.0 h1:3gD5McaYs9CxjyK5AXGcq8gdeCARtd/9gJDUvVeaZ0Y=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/paulmach/orb v0.1.3/go.mod h1:VFlX/8C+IQ1p6FTRRKzKoOPJnvEtA5G0Veuqwbu//Vk=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -900,12 +903,8 @@ mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZI
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/kustomize/api v0.3.3 h1:E3nUKiTnezsA1NoGA37jWlatjjMq2a/i1UIGAzSZGnk=
-sigs.k8s.io/kustomize/api v0.3.3/go.mod h1:JU8ooABgAO6xVDiWThwKtKShI8phhAALPaMfBpmNDOM=
 sigs.k8s.io/kustomize/api v0.4.1 h1:Lwco6Rsxd3TcubJzx9wAV2k7roh0M95FjrS29n76TRo=
 sigs.k8s.io/kustomize/api v0.4.1/go.mod h1:NqxqT+wbYHrD0P19Uu4dXiMsVwI1IwQs+MJHlLhmPqQ=
-sigs.k8s.io/kustomize/kyaml v0.1.10 h1:ZZfBnA/kYa9ZxUFIgI9oq3pWKzzA1gGOKgU0Hv/NhVg=
-sigs.k8s.io/kustomize/kyaml v0.1.10/go.mod h1:mPmeBSRy0LTMv6fSrYSoi2yIFNZVouGKDsTekE5kdhs=
 sigs.k8s.io/kustomize/kyaml v0.1.11 h1:/VvWxVIgH5gG1K4A7trgbyLgO3tRBiAWNhLFVU1HEmo=
 sigs.k8s.io/kustomize/kyaml v0.1.11/go.mod h1:72/rLkSi+L/pHM1oCjwrf3ClU+tH5kZQvvdLSqIHwWU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=

--- a/kustomize/provider.go
+++ b/kustomize/provider.go
@@ -3,22 +3,26 @@ package kustomize
 import (
 	"fmt"
 	"io/ioutil"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
+	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/mitchellh/go-homedir"
+	"github.com/patrickmn/go-cache"
 )
 
 // Config ...
 type Config struct {
-	Client    dynamic.Interface
-	Clientset *kubernetes.Clientset
+	Client                 dynamic.Interface
+	CachedGroupVersionKind cachedGroupVersionKind
 }
 
 const kubeconfigDefault = "~/.kube/config"
@@ -98,7 +102,9 @@ func Provider() *schema.Provider {
 			return nil, err
 		}
 
-		return &Config{client, clientset}, nil
+		cgvk := newCachedGroupVersionKind(clientset)
+
+		return &Config{client, cgvk}, nil
 	}
 
 	return p
@@ -135,4 +141,49 @@ func getClientConfig(data []byte, context string) (*rest.Config, error) {
 		nil)
 
 	return clientConfig.ClientConfig()
+}
+
+func newCachedGroupVersionKind(cs *kubernetes.Clientset) cachedGroupVersionKind {
+	cache := cache.New(1*time.Minute, 1*time.Minute)
+
+	return cachedGroupVersionKind{
+		cs:    cs,
+		cache: cache,
+	}
+}
+
+type cachedGroupVersionKind struct {
+	cs    *kubernetes.Clientset
+	cache *cache.Cache
+}
+
+const APIGroupResourcesCacheKey string = "restmapper.GetAPIGroupResources"
+
+func (c cachedGroupVersionKind) getGVR(gvk k8sschema.GroupVersionKind, refreshCache bool) (gvr k8sschema.GroupVersionResource, err error) {
+	var agr []*restmapper.APIGroupResources
+
+	cachedAgr, found := c.cache.Get(APIGroupResourcesCacheKey)
+	if found {
+		agr = cachedAgr.([]*restmapper.APIGroupResources)
+	}
+
+	if found == false || refreshCache == true {
+		agr, err = restmapper.GetAPIGroupResources(c.cs.Discovery())
+		if err != nil {
+			return gvr, fmt.Errorf("discovering API group resources failed: %s", err)
+		}
+		c.cache.Set(APIGroupResourcesCacheKey, agr, cache.DefaultExpiration)
+	}
+
+	rm := restmapper.NewDiscoveryRESTMapper(agr)
+
+	gk := k8sschema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}
+	mapping, err := rm.RESTMapping(gk, gvk.Version)
+	if err != nil {
+		return gvr, fmt.Errorf("mapping GroupKind failed for '%s': %s", gvk, err)
+	}
+
+	gvr = mapping.Resource
+
+	return gvr, nil
 }

--- a/kustomize/resource_kustomization.go
+++ b/kustomize/resource_kustomization.go
@@ -41,7 +41,7 @@ func kustomizationResource() *schema.Resource {
 
 func kustomizationResourceCreate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*Config).Client
-	clientset := m.(*Config).Clientset
+	cgvk := m.(*Config).CachedGroupVersionKind
 
 	srcJSON := d.Get("manifest").(string)
 	u, err := parseJSON(srcJSON)
@@ -55,7 +55,7 @@ func kustomizationResourceCreate(d *schema.ResourceData, m interface{}) error {
 		Timeout: d.Timeout(schema.TimeoutCreate),
 		Refresh: func() (interface{}, string, error) {
 			// CRDs: wait for GroupVersionKind to exist
-			gvr, err := getGVR(u.GroupVersionKind(), clientset)
+			gvr, err := cgvk.getGVR(u.GroupVersionKind(), true)
 			if err != nil {
 				return nil, "pending", nil
 			}
@@ -82,7 +82,7 @@ func kustomizationResourceCreate(d *schema.ResourceData, m interface{}) error {
 			Group:   "",
 			Version: "",
 			Kind:    "Namespace"}
-		nsGvr, err := getGVR(nsGvk, clientset)
+		nsGvr, err := cgvk.getGVR(nsGvk, false)
 		if err != nil {
 			return fmt.Errorf("ResourceCreate: %s", err)
 		}
@@ -132,14 +132,14 @@ func kustomizationResourceCreate(d *schema.ResourceData, m interface{}) error {
 
 func kustomizationResourceRead(d *schema.ResourceData, m interface{}) error {
 	client := m.(*Config).Client
-	clientset := m.(*Config).Clientset
+	cgvk := m.(*Config).CachedGroupVersionKind
 
 	u, err := parseJSON(d.Get("manifest").(string))
 	if err != nil {
 		return fmt.Errorf("ResourceRead: %s", err)
 	}
 
-	gvr, err := getGVR(u.GroupVersionKind(), clientset)
+	gvr, err := cgvk.getGVR(u.GroupVersionKind(), false)
 	if err != nil {
 		return fmt.Errorf("ResourceRead: %s", err)
 	}
@@ -164,7 +164,7 @@ func kustomizationResourceRead(d *schema.ResourceData, m interface{}) error {
 
 func kustomizationResourceDiff(d *schema.ResourceDiff, m interface{}) error {
 	client := m.(*Config).Client
-	clientset := m.(*Config).Clientset
+	cgvk := m.(*Config).CachedGroupVersionKind
 
 	originalJSON, modifiedJSON := d.GetChange("manifest")
 
@@ -181,7 +181,7 @@ func kustomizationResourceDiff(d *schema.ResourceDiff, m interface{}) error {
 		return fmt.Errorf("ResourceDiff: %s", err)
 	}
 
-	gvr, err := getGVR(u.GroupVersionKind(), clientset)
+	gvr, err := cgvk.getGVR(u.GroupVersionKind(), false)
 	if err != nil {
 		return fmt.Errorf("ResourceDiff: %s", err)
 	}
@@ -235,14 +235,14 @@ func kustomizationResourceDiff(d *schema.ResourceDiff, m interface{}) error {
 
 func kustomizationResourceExists(d *schema.ResourceData, m interface{}) (bool, error) {
 	client := m.(*Config).Client
-	clientset := m.(*Config).Clientset
+	cgvk := m.(*Config).CachedGroupVersionKind
 
 	u, err := parseJSON(d.Get("manifest").(string))
 	if err != nil {
 		return false, fmt.Errorf("ResourceExists: %s", err)
 	}
 
-	gvr, err := getGVR(u.GroupVersionKind(), clientset)
+	gvr, err := cgvk.getGVR(u.GroupVersionKind(), false)
 	if err != nil {
 		return false, fmt.Errorf("ResourceExists: %s", err)
 	}
@@ -265,7 +265,7 @@ func kustomizationResourceExists(d *schema.ResourceData, m interface{}) (bool, e
 
 func kustomizationResourceUpdate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*Config).Client
-	clientset := m.(*Config).Clientset
+	cgvk := m.(*Config).CachedGroupVersionKind
 
 	originalJSON, modifiedJSON := d.GetChange("manifest")
 
@@ -282,7 +282,7 @@ func kustomizationResourceUpdate(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("ResourceUpdate: %s", err)
 	}
 
-	gvr, err := getGVR(u.GroupVersionKind(), clientset)
+	gvr, err := cgvk.getGVR(u.GroupVersionKind(), false)
 	if err != nil {
 		return fmt.Errorf("ResourceUpdate: %s", err)
 	}
@@ -321,14 +321,14 @@ func kustomizationResourceUpdate(d *schema.ResourceData, m interface{}) error {
 
 func kustomizationResourceDelete(d *schema.ResourceData, m interface{}) error {
 	client := m.(*Config).Client
-	clientset := m.(*Config).Clientset
+	cgvk := m.(*Config).CachedGroupVersionKind
 
 	u, err := parseJSON(d.Get("manifest").(string))
 	if err != nil {
 		return fmt.Errorf("ResourceDelete: %s", err)
 	}
 
-	gvr, err := getGVR(u.GroupVersionKind(), clientset)
+	gvr, err := cgvk.getGVR(u.GroupVersionKind(), false)
 	if err != nil {
 		return fmt.Errorf("ResourceDelete: %s", err)
 	}
@@ -380,7 +380,7 @@ func kustomizationResourceDelete(d *schema.ResourceData, m interface{}) error {
 
 func kustomizationResourceImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	client := m.(*Config).Client
-	clientset := m.(*Config).Clientset
+	cgvk := m.(*Config).CachedGroupVersionKind
 
 	rid := resid.FromString(d.Id())
 
@@ -389,7 +389,7 @@ func kustomizationResourceImport(d *schema.ResourceData, m interface{}) ([]*sche
 		Version: rid.Gvk.Version,
 		Kind:    rid.Gvk.Kind,
 	}
-	gvr, err := getGVR(gvk, clientset)
+	gvr, err := cgvk.getGVR(gvk, false)
 	if err != nil {
 		return nil, fmt.Errorf("ResourceImport: %s", err)
 	}

--- a/kustomize/resource_kustomization_test.go
+++ b/kustomize/resource_kustomization_test.go
@@ -365,9 +365,9 @@ func getResourceFromTestState(s *terraform.State, n string) (ur *k8sunstructured
 
 func getResourceFromK8sAPI(u *k8sunstructured.Unstructured) (resp *k8sunstructured.Unstructured, err error) {
 	client := testAccProvider.Meta().(*Config).Client
-	clientset := testAccProvider.Meta().(*Config).Clientset
+	cgvk := testAccProvider.Meta().(*Config).CachedGroupVersionKind
 
-	gvr, err := getGVR(u.GroupVersionKind(), clientset)
+	gvr, err := cgvk.getGVR(u.GroupVersionKind(), false)
 	if err != nil {
 		return nil, err
 	}

--- a/kustomize/util.go
+++ b/kustomize/util.go
@@ -9,9 +9,6 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/restmapper"
 
 	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
 	"k8s.io/apimachinery/pkg/util/mergepatch"
@@ -34,7 +31,7 @@ func getLastAppliedConfig(u *k8sunstructured.Unstructured) string {
 
 func getOriginalModifiedCurrent(originalJSON string, modifiedJSON string, currentAllowNotFound bool, m interface{}) (original []byte, modified []byte, current []byte, err error) {
 	client := m.(*Config).Client
-	clientset := m.(*Config).Clientset
+	cgvk := m.(*Config).CachedGroupVersionKind
 
 	n, err := parseJSON(modifiedJSON)
 	if err != nil {
@@ -48,7 +45,7 @@ func getOriginalModifiedCurrent(originalJSON string, modifiedJSON string, curren
 	setLastAppliedConfig(o, originalJSON)
 	setLastAppliedConfig(n, modifiedJSON)
 
-	gvr, err := getGVR(o.GroupVersionKind(), clientset)
+	gvr, err := cgvk.getGVR(o.GroupVersionKind(), false)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -96,25 +93,6 @@ func getPatch(original []byte, modified []byte, current []byte) (patch []byte, e
 		return nil, fmt.Errorf("CreateThreeWayJSONMergePatch failed: %s", err)
 	}
 	return patch, nil
-}
-
-func getGVR(gvk k8sschema.GroupVersionKind, cs *kubernetes.Clientset) (gvr k8sschema.GroupVersionResource, err error) {
-	agr, err := restmapper.GetAPIGroupResources(cs.Discovery())
-	if err != nil {
-		return gvr, fmt.Errorf("discovering API group resources failed: %s", err)
-	}
-
-	rm := restmapper.NewDiscoveryRESTMapper(agr)
-
-	gk := k8sschema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}
-	mapping, err := rm.RESTMapping(gk, gvk.Version)
-	if err != nil {
-		return gvr, fmt.Errorf("mapping GroupKind failed for '%s': %s", gvk, err)
-	}
-
-	gvr = mapping.Resource
-
-	return gvr, nil
 }
 
 func parseJSON(json string) (ur *k8sunstructured.Unstructured, err error) {


### PR DESCRIPTION
To be able to map a resource kind to a REST url, the go client
requires the list of resources the current cluster supports.

The previous implementation naively makes a request to the K8s
API before every request. This results in 259 calls to
`restmapper.GetAPIGroupResources` even though the list rarely
changes. I'm assuming it only does when a custom resource gets
added or removed, or when the K8s API is updated.

Even with the relatively high QPS and Burst values we set, this
frequently resulted in requests being throttled, slowing the
provider down.

This change reduces the number of calls during tests from 259
to 120 by caching the response in memory.