### PR TITLE
Append version to binary name, to fix `terraform -v`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ test:
 RELEASE := $(shell git describe --tags)
 
 release-binaries:
-	GOOS=linux GOARCH=amd64 go build -o terraform.d/plugins/linux_amd64/terraform-provider-kustomization
-	tar -caf terraform-provider-kustomization-linux-amd64_$(RELEASE).tgz terraform.d/plugins/linux_amd64/terraform-provider-kustomization
+	GOOS=linux GOARCH=amd64 go build -o terraform.d/plugins/linux_amd64/terraform-provider-kustomization_$(RELEASE)
+	tar -caf terraform-provider-kustomization-linux-amd64_$(RELEASE).tgz terraform.d/plugins/linux_amd64/terraform-provider-kustomization_$(RELEASE)
 	
-	GOOS=darwin GOARCH=amd64 go build -o terraform.d/plugins/darwin_amd64/terraform-provider-kustomization
-	tar -caf terraform-provider-kustomization-darwin-amd64_$(RELEASE).tgz terraform.d/plugins/darwin_amd64/terraform-provider-kustomization
+	GOOS=darwin GOARCH=amd64 go build -o terraform.d/plugins/darwin_amd64/terraform-provider-kustomization_$(RELEASE)
+	tar -caf terraform-provider-kustomization-darwin-amd64_$(RELEASE).tgz terraform.d/plugins/darwin_amd64/terraform-provider-kustomization_$(RELEASE)
 
-	GOOS=windows GOARCH=amd64 go build -o terraform.d/plugins/windows_amd64/terraform-provider-kustomization
-	tar -caf terraform-provider-kustomization-windows-amd64_$(RELEASE).tgz terraform.d/plugins/windows_amd64/terraform-provider-kustomization
+	GOOS=windows GOARCH=amd64 go build -o terraform.d/plugins/windows_amd64/terraform-provider-kustomization_$(RELEASE)
+	tar -caf terraform-provider-kustomization-windows-amd64_$(RELEASE).tgz terraform.d/plugins/windows_amd64/terraform-provider-kustomization_$(RELEASE)


### PR DESCRIPTION
Without the version attached to the file name, the provider is
reported as unversioned by Terraform.

```
$ terraform -v
Terraform v0.12.24
+ provider.kustomization (unversioned)
```