### PR TITLE
Ignore Kind mapping error in Exists and Delete methods

### DIFF
--- a/kustomize/resource_kustomization.go
+++ b/kustomize/resource_kustomization.go
@@ -244,7 +244,9 @@ func kustomizationResourceExists(d *schema.ResourceData, m interface{}) (bool, e
 
 	gvr, err := cgvk.getGVR(u.GroupVersionKind(), false)
 	if err != nil {
-		return false, fmt.Errorf("ResourceExists: %s", err)
+		// If the Kind does not exist in the K8s API,
+		// the resource can't exist either
+		return false, nil
 	}
 	namespace := u.GetNamespace()
 	name := u.GetName()
@@ -330,7 +332,9 @@ func kustomizationResourceDelete(d *schema.ResourceData, m interface{}) error {
 
 	gvr, err := cgvk.getGVR(u.GroupVersionKind(), false)
 	if err != nil {
-		return fmt.Errorf("ResourceDelete: %s", err)
+		// If the Kind does not exist in the K8s API,
+		// the resource can't exist either
+		return nil
 	}
 	namespace := u.GetNamespace()
 	name := u.GetName()


### PR DESCRIPTION
Both, when checking if a resource exists or when deleting it,
we do not need to treat it as an error if the K8s API does not
know that Kind.

If the Kind is unknown to K8s:
 * During exists, the resource can not exists
 * During delete, we can consider the resource deleted.