### PR TITLE
Control order of resource IDs in Set fix #36

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -465,7 +465,6 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/patrickmn/go-cache v1.0.0 h1:3gD5McaYs9CxjyK5AXGcq8gdeCARtd/9gJDUvVeaZ0Y=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/paulmach/orb v0.1.3/go.mod h1:VFlX/8C+IQ1p6FTRRKzKoOPJnvEtA5G0Veuqwbu//Vk=


### PR DESCRIPTION
The Terraform SDKs Set implementation returns entries [sorted][0]
based of the hashed int IDs. This resulted in K8s resources returned
from the Kustomize build to not preserve [Kustomize's default order][1].

Since there is no way to control the dependency graph from within a
provider, from Terraform's perspective all resources coming from a
Kustomize build have no dependencies.

 * Explicitly setting `depends_on` is not an option, because it
   does not allow the use of variables
 * Additionally, referencing a TF resource that includes `for_each`
   will result in a dependency on the complete list of resources
   resulting in dependency cycles

But because Terraform by default only does 10 resources in
parallel, there was a edge case that the first 10 resources in
the Set depend on a namespace and that namespace is the 11th entry.

Due to the lack of dependencies between the resources, the provider
on creating a namespaced or custom object, loops and waits for the
namespace or custom resource definition to be applied already.

This means, in the 10 namespaced resources and the namespaced is
the 11th resource scenario, that we could end up having 10
resources loop until timeout.

Since solving this using the preferrable dependency approach is not
an option, I had to solve it by falling back to ordering of resources.

This PR uses the `SchemaSetFunc` to provide custom ordering of
resources in the Terraform Set implementation by prefixing `01` to
`Namespace` and `CustomResourceDefinition` Kinds and `09` to
`MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration`
Kinds. All other Kinds get `05` prefixed.

I've validated that this fixes the edge case with Istio as
described in #36. As a side effect, it also increases apply runtime
in general, because there is less looping due to the new resource order.

[0]: https://github.com/hashicorp/terraform-plugin-sdk/blob/v1.4.0/helper/schema/set.go#L244
[1]: https://github.com/kubernetes-sigs/kustomize/blob/api/v0.4.1/api/resid/gvk.go#L78