### PR TITLE
Fix getGVR error handling

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -879,6 +879,7 @@ k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=
 k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
+k8s.io/apimachinery v0.19.0 h1:gjKnAda/HZp5k4xQYjL0K/Yb66IvNqjthCb03QlKpaQ=
 k8s.io/client-go v0.17.0 h1:8QOGvUGdqDMFrm9sD6IUFl256BcffynGoe80sxgTEDg=
 k8s.io/client-go v0.17.0/go.mod h1:TYgR6EUHs6k45hb6KWjVD6jFZvJV4gHDikv/It0xz+k=
 k8s.io/client-go v0.18.2 h1:aLB0iaD4nmwh7arT2wIn+lMnAq7OswjaejkQ8p9bBYE=

--- a/kustomize/provider.go
+++ b/kustomize/provider.go
@@ -170,7 +170,7 @@ func (c cachedGroupVersionKind) getGVR(gvk k8sschema.GroupVersionKind, refreshCa
 	if found == false || refreshCache == true {
 		agr, err = restmapper.GetAPIGroupResources(c.cs.Discovery())
 		if err != nil {
-			return gvr, fmt.Errorf("discovering API group resources failed: %s", err)
+			return gvr, err
 		}
 		c.cache.Set(APIGroupResourcesCacheKey, agr, cache.DefaultExpiration)
 	}
@@ -180,7 +180,7 @@ func (c cachedGroupVersionKind) getGVR(gvk k8sschema.GroupVersionKind, refreshCa
 	gk := k8sschema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}
 	mapping, err := rm.RESTMapping(gk, gvk.Version)
 	if err != nil {
-		return gvr, fmt.Errorf("mapping GroupKind failed for '%s': %s", gvk, err)
+		return gvr, err
 	}
 
 	gvr = mapping.Resource


### PR DESCRIPTION
The previous implementation did not allow checking for the specific
K8s API error and in the case of ResourceCreate let to retrying even
e.g. connection errors.