### PR TITLE
Fix release artifacts and document TF 0.13 usage and depreciation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,8 +86,8 @@ jobs:
     - name: 'Prepare provider binary'
       run: |
         mkdir -p ./terraform.d/plugins/linux_amd64/
-        cp ./dist/terraform-provider-kustomization_linux_amd64/terraform-provider-kustomization_* ./terraform.d/plugins/linux_amd64/
-        chmod +x ./terraform.d/plugins/linux_amd64/terraform-provider-kustomization_*
+        cp ./dist/terraform-provider-kustomize_linux_amd64/terraform-provider-kustomize_* ./terraform.d/plugins/linux_amd64/terraform-provider-kustomization
+        chmod +x ./terraform.d/plugins/linux_amd64/terraform-provider-kustomization
 
     - name: 'Setup Kind'
       uses: engineerd/setup-kind@v0.1.0
@@ -132,8 +132,8 @@ jobs:
     - name: 'Prepare provider binary'
       run: |
         mkdir -p ./terraform.d/plugins/linux_amd64/
-        cp ./dist/terraform-provider-kustomization_linux_amd64/terraform-provider-kustomization_* ./terraform.d/plugins/linux_amd64/
-        chmod +x ./terraform.d/plugins/linux_amd64/terraform-provider-kustomization_*
+        cp ./dist/terraform-provider-kustomize_linux_amd64/terraform-provider-kustomize_* ./terraform.d/plugins/linux_amd64/terraform-provider-kustomization
+        chmod +x ./terraform.d/plugins/linux_amd64/terraform-provider-kustomization
 
     - name: 'Create provider.tf with kubeconfig_raw'
       run: |
@@ -178,8 +178,8 @@ jobs:
     - name: 'Prepare provider binary'
       run: |
         mkdir -p ./terraform.d/plugins/linux_amd64/
-        cp ./dist/terraform-provider-kustomization_linux_amd64/terraform-provider-kustomization_* ./terraform.d/plugins/linux_amd64/
-        chmod +x ./terraform.d/plugins/linux_amd64/terraform-provider-kustomization_*
+        cp ./dist/terraform-provider-kustomize_linux_amd64/terraform-provider-kustomize_* ./terraform.d/plugins/linux_amd64/terraform-provider-kustomization
+        chmod +x ./terraform.d/plugins/linux_amd64/terraform-provider-kustomization
 
     - name: 'Set KUBECONFIG env var'
       run: |

--- a/.goreleaser-build.yml
+++ b/.goreleaser-build.yml
@@ -1,4 +1,3 @@
-project_name: terraform-provider-kustomization
 before:
   hooks:
     - go mod tidy

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
-  binary: 'terraform-provider-kustomization_v{{ .Version }}'
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip
   # artifact need to match the repository name,

--- a/docs/data-sources/kustomization.md
+++ b/docs/data-sources/kustomization.md
@@ -4,16 +4,25 @@ Data source to `kustomize build` a kustomization and return a set of `ids` and h
 
 ## Example Usage
 
+!> Please note the difference between the local provider name `kustomization` and the registry source `source = "kbst/kustomize"`. This unconventional naming requires specifying the provider attribute for every resource. To resolve this, this will be the last release of this provider as `kbst/kustomize` all future versions will be released as `kbst/kustomization`.
+
 ```hcl
-data "kustomization" "example" {
-  # path to kustomization directory
-  path = "test_kustomizations/basic/initial"
+terraform {
+  required_providers {
+    kustomization = {
+      source  = "kbst/kustomize"
+      version = "v0.2.0-beta.3"
+    }
+  }
+  required_version = ">= 0.12"
 }
 
-resource "kustomization_resource" "example" {
-  for_each = data.kustomization.example.ids
+provider "kustomization" {}
 
-  manifest = data.kustomization.example.manifests[each.value]
+data "kustomization" "test" {
+  provider = kustomization
+
+  path = "test_kustomizations/basic/initial"
 }
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,17 +14,20 @@ As such it can be useful both to replace kustomize/kubectl integrated into a Ter
 
 ## Example Usage
 
+!> Please note the difference between the local provider name `kustomization` and the registry source `source = "kbst/kustomize"`. This unconventional naming requires specifying the provider attribute for every resource. To resolve this, this will be the last release of this provider as `kbst/kustomize` all future versions will be released as `kbst/kustomization`.
+
 ```hcl
-data "kustomization" "example" {
-  # path to kustomization directory
-  path = "test_kustomizations/basic/initial"
+terraform {
+  required_providers {
+    kustomization = {
+      source  = "kbst/kustomize"
+      version = "v0.2.0-beta.3"
+    }
+  }
+  required_version = ">= 0.12"
 }
 
-resource "kustomization_resource" "example" {
-  for_each = data.kustomization.example.ids
-
-  manifest = data.kustomization.example.manifests[each.value]
-}
+provider "kustomization" {}
 
 ```
 

--- a/docs/resources/kustomization_resource.md
+++ b/docs/resources/kustomization_resource.md
@@ -4,16 +4,33 @@ Resource to provision JSON encoded Kubernetes resource manifests as produced by 
 
 ## Example Usage
 
+!> Please note the difference between the local provider name `kustomization` and the registry source `source = "kbst/kustomize"`. This unconventional naming requires specifying the provider attribute for every resource. To resolve this, this will be the last release of this provider as `kbst/kustomize` all future versions will be released as `kbst/kustomization`.
+
 ```hcl
-data "kustomization" "example" {
-  # path to kustomization directory
+terraform {
+  required_providers {
+    kustomization = {
+      source  = "kbst/kustomize"
+      version = "v0.2.0-beta.3"
+    }
+  }
+  required_version = ">= 0.12"
+}
+
+provider "kustomization" {}
+
+data "kustomization" "test" {
+  provider = kustomization
+
   path = "test_kustomizations/basic/initial"
 }
 
-resource "kustomization_resource" "example" {
-  for_each = data.kustomization.example.ids
+resource "kustomization_resource" "test" {
+  provider = kustomization
 
-  manifest = data.kustomization.example.manifests[each.value]
+  for_each = data.kustomization.test.ids
+
+  manifest = data.kustomization.test.manifests[each.value]
 }
 
 ```


### PR DESCRIPTION
The unconventional naming of repository, provider and resource/data source
causes issues when Terraform downloads the provider from the registry
and complicates usage.

https://github.com/kbst/terraform-provider-kustomize/issues/57

This version will document the usage and inform users this will
be the last version released as `kbst/kustomize`.